### PR TITLE
Updated sleep script extractor to work with DisplayLink driver 1.2.58…

### DIFF
--- a/displaylink-sleep-extractor.sh
+++ b/displaylink-sleep-extractor.sh
@@ -2,7 +2,7 @@
 file=$1
 
 startline=$(grep -n "add_pm_script()" "$file" | cut -d: -f1 |head -1)
-endline=$(grep -n 'chmod 0755 $COREDIR/displaylink.sh' "$file" | cut -d: -f1 |head -1)
+endline=$(grep -n 'chmod 0755 $COREDIR/suspend.sh' "$file" | cut -d: -f1 |head -1)
 
 source <(
 	tail -n +$startline $file | head -n +$(($endline - $startline)) &&
@@ -11,6 +11,6 @@ source <(
 COREDIR=$(mktemp -d)
 add_pm_script "systemd"
 
-cat "$COREDIR/displaylink.sh"
+cat "$COREDIR/suspend.sh"
 
 rm -rf "$COREDIR"

--- a/displaylink.spec
+++ b/displaylink.spec
@@ -3,7 +3,7 @@
 
 Name:		displaylink
 Version:	1.2.55
-Release:	1
+Release:	2
 Summary:	DisplayLink VGA/HDMI driver for DL-5xxx, DL-41xx and DL-3xxx adapters
 
 Group:		User Interface/X Hardware Support
@@ -113,6 +113,9 @@ fi
 /usr/bin/systemctl daemon-reload
 
 %changelog
+* Tue Oct 04 2016 Victor Rehorst <victor@chuma.org> 1.2.55-2
+- Fix systemd-sleep support for DisplayLink driver 1.2.58 (which is now current for v1.2)
+
 * Thu Sep 22 2016 Santiago Saavedra <ssaavedra@gpul.org> 1.2.55-1
 - Bump upstream version for both evdi and DisplayLink driver
 


### PR DESCRIPTION
Just tried building this RPM with DisplayLink driver 1.2.58 and found it didn't build.  

The reason being that DisplayLink changed the name of the systemd-sleep script from "displaylink.sh" to "suspend.sh", which caused displaylink-sleep-extractor.sh to fail.